### PR TITLE
Bumped versions and added auto-service

### DIFF
--- a/jar-module/pom.xml
+++ b/jar-module/pom.xml
@@ -41,6 +41,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/jar-module/src/main/java/de/tdlabs/keycoak/ext/storage/demo/DemoUserStorageProvider.java
+++ b/jar-module/src/main/java/de/tdlabs/keycoak/ext/storage/demo/DemoUserStorageProvider.java
@@ -57,7 +57,7 @@ public class DemoUserStorageProvider implements UserStorageProvider,
     }
 
     UserCredentialModel cred = (UserCredentialModel) input;
-    return repository.validateCredentials(user.getUsername(), cred.getValue());
+    return repository.validateCredentials(user.getUsername(), cred.getChallengeResponse());
   }
 
   @Override
@@ -70,7 +70,7 @@ public class DemoUserStorageProvider implements UserStorageProvider,
     }
 
     UserCredentialModel cred = (UserCredentialModel) input;
-    return repository.updateCredentials(user.getUsername(), cred.getValue());
+    return repository.updateCredentials(user.getUsername(), cred.getChallengeResponse());
   }
 
   @Override

--- a/jar-module/src/main/java/de/tdlabs/keycoak/ext/storage/demo/DemoUserStorageProviderFactory.java
+++ b/jar-module/src/main/java/de/tdlabs/keycoak/ext/storage/demo/DemoUserStorageProviderFactory.java
@@ -1,5 +1,6 @@
 package de.tdlabs.keycoak.ext.storage.demo;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.Lists;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
@@ -12,6 +13,7 @@ import org.keycloak.storage.UserStorageProviderFactory;
 import java.util.List;
 
 @JBossLog
+@AutoService(UserStorageProviderFactory.class)
 public class DemoUserStorageProviderFactory implements UserStorageProviderFactory<DemoUserStorageProvider> {
 
   @Override

--- a/jar-module/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/jar-module/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -1,1 +1,0 @@
-de.tdlabs.keycoak.ext.storage.demo.DemoUserStorageProviderFactory

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,21 @@
         <lombok.version>1.18.12</lombok.version>
         <jboss-logging.version>3.3.1.Final</jboss-logging.version>
         <keycloak.version>8.0.1</keycloak.version>
-
+        <auto-service.version>1.0-rc5</auto-service.version>
         <jboss.home>target/keycloak</jboss.home>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${auto-service.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.18.12</lombok.version>
         <jboss-logging.version>3.3.1.Final</jboss-logging.version>
-        <keycloak.version>3.3.0.CR1</keycloak.version>
+        <keycloak.version>8.0.1</keycloak.version>
 
         <jboss.home>target/keycloak</jboss.home>
     </properties>
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <version>7</version>
                 </configuration>


### PR DESCRIPTION
Hi Thomas,

bumped the Keycloak-Version to 8.0.1 and fixed an error with the credentials. The demo should now be usable for newer Keycloak versions.

Added auto-service as a replacement for manual META-INF/services.

Best regards
Thomas